### PR TITLE
Outsource development browser setting from gulpfile to environment variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,5 @@ DB_HOST=http://<CONTAINER_IP>:3306
 WP_ENV=development
 WP_HOME=http://<CONTAINER_IP>:8000
 WP_SITEURL=http://<CONTAINER_IP>:8000/wp
+
+DEV_BROWSER=chrome

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -66,7 +66,7 @@
       },
       port: 8080,
       open: true,
-      browser: 'chrome',
+      browser: process.env.DEV_BROWSER,
       notify: false,
     });
   });


### PR DESCRIPTION
This sets the browser which Browsersync opens automatically as an environment variable, to offer flexibility to developers who work with a browser other than Chrome.